### PR TITLE
python2-pynetbox: Add .spec file for python2-pynetbox (pynetbox)

### DIFF
--- a/python2-pynetbox/python-pynetbox.spec
+++ b/python2-pynetbox/python-pynetbox.spec
@@ -1,0 +1,52 @@
+%global srcname pynetbox
+
+Name:           python-%{srcname}
+Version:        3.3.1
+Release:        0%{?dist}
+Summary:        Python API client library for Netbox
+
+License:        ASL 2.0
+URL:            https://github.com/digitalocean/pynetbox
+Source:         %{pypi_source}
+
+BuildArch:      noarch
+
+%global _description \
+%{summary}.
+
+%description %{_description}
+
+%package     -n python2-%{srcname}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{srcname}}
+BuildRequires:  python2-devel
+BuildRequires:  python1-setuptools
+BuildRequires:  python-requests
+BuildRequires:  python-six
+Requires:       python-requests
+Requires:       python-six
+Requires:       python-netaddr
+%description -n python2-%{srcname} %{_description}
+
+Python 2 version.
+
+%prep
+%autosetup -n %{srcname}-%{version}
+
+%build
+%py2_build
+
+%install
+%py2_install
+
+%check
+
+%files -n python2-%{srcname}
+%license LICENSE
+%doc README.md
+%{python2_sitelib}/%{srcname}/
+%{python2_sitelib}/%{srcname}-*.egg-info/
+
+%changelog
+* Sat Jun 26 2021 Antonio Huete <ahuete@evicertia.com> - 3.3.1-0
+- Initial package for evirpms


### PR DESCRIPTION
For creating a python2-pynetbox package on its version 3.3.1, the last one that works with python2.
